### PR TITLE
Process .m and .h files in an xcode project

### DIFF
--- a/bin/whitespace
+++ b/bin/whitespace
@@ -6,7 +6,7 @@
 # Also:
 # - converts tabs to spaces
 # - ensures a single newline at the end
-FILE_TYPES = "rb|js|haml|html|css|sass|coffee"
+FILE_TYPES = "rb|js|haml|html|css|sass|coffee|m|h"
 
 class WhitespaceProcessor
   def self.process(code)
@@ -31,11 +31,13 @@ class WhitespaceProcessor
   end
 end
 
+regex = "\\.(#{FILE_TYPES})[^:alphanumeric]?$"
+
 if ARGV.include?('--all')
-  files = `find . -type file | grep -v .git | grep -v ./vendor | grep -v ./tmp  | egrep ".(#{FILE_TYPES})"`.split(/\n/)
+  files = `find . -type file | grep -v .git | grep -v ./vendor | grep -v ./tmp  | egrep "#{regex}"`.split(/\n/)
   puts "* Stripping whitespace from all project files"
 else
-  files = `git status | egrep ".(#{FILE_TYPES})"`.split("\n").select { |file| file =~ /^#\t(modified|new file|renamed):/ }
+  files = `git status | egrep "#{regex}"`.split("\n").select { |file| file =~ /^#\t(modified|new file|renamed):/ }
   puts "* Stripping whitespace from modified files."
 end
 


### PR DESCRIPTION
1. Adds .m and .h to the file types
2. Improves the regular expression used for file name matching.

The regex was previously matching any character followed by the file name, eg aarb.exe. 

This fixes it to match a . character, one of the file names, an optional non-alphanumeric character and the end of the line.

The optional non-alphanumeric character is useful in xcode projects which sometimes contain spaces and have a " at the end of the file name.
